### PR TITLE
feat: add baseURI override for local service requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
+const { highpoint: { 'x-server-url': xServerUrl } = {} } = self.window;
+
 const getBaseURI = () =>
+  xServerUrl ||
   (document.baseURI || document.querySelector('base').href).replace(
     /IScript_.*/,
     'IScript_'

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-const { highpoint: { 'x-server-url': xServerUrl } = {} } = self.window;
+const { highpoint: { dataURI } = {} } = self.window;
 
 const getBaseURI = () =>
-  xServerUrl ||
+  dataURI ||
   (document.baseURI || document.querySelector('base').href).replace(
     /IScript_.*/,
     'IScript_'


### PR DESCRIPTION
Colton and Luis have evaluated backend functionality similar to the local asset redirection we use on the frontend that can redirect json service calls to a local development server. If the request header 'x-server-url' is applied through a mod header w/ the value being the base url of the local dev webserver, that url will be passed in the bootstrap data of the Main service as 'highpoint.x-server-url'. 

The change that is made to this package is to check for the highpoint.x-server-url value and use it instead of the document.baseURI if it is present. If a page is requested with the mod header enabled, then the alternative base url will be used for all service calls.
![image](https://user-images.githubusercontent.com/27093658/83053371-78c9e780-a005-11ea-8357-1b1c3fb0a627.png)
