### PR TITLE
feat: Redirect IScript urls if using the baseURI override

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,11 @@ const getBaseURI = () =>
     'IScript_'
   );
 
+const getUrlOrRedirect = url =>
+  dataURI && url.includes('IScript_')
+    ? url.replace(/.*IScript_/, dataURI)
+    : url;
+
 const isFramed = (() => {
   try {
     if (self.window === undefined) return false;
@@ -62,12 +67,15 @@ const doFetch = (
     window.parent.postMessage('is-active', '*'); // Let parent know child is active
   }
   if (isOffline()) throw new Error('Network Error. Are you offline?');
-  return fetch(url.indexOf('http') === 0 ? url : getBaseURI() + url, {
-    method,
-    credentials,
-    headers: { accept, ...headers },
-    ...otherArgs
-  });
+  return fetch(
+    url.indexOf('http') === 0 ? getUrlOrRedirect(url) : getBaseURI() + url,
+    {
+      method,
+      credentials,
+      headers: { accept, ...headers },
+      ...otherArgs
+    }
+  );
 };
 
 const doPost = (url, { method = 'POST', headers = {}, ...otherArgs } = {}) =>

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,14 @@
 const { highpoint: { dataURI } = {} } = self.window;
 
-const getBaseURI = () =>
-  dataURI ||
-  (document.baseURI || document.querySelector('base').href).replace(
-    /IScript_.*/,
-    'IScript_'
-  );
+const getBaseURI = () => {
+  const baseURI = (
+    document.baseURI || document.querySelector('base').href
+  ).replace(/IScript_.*/, 'IScript_');
+  return dataURI ? baseURI.replace(/.*\//, dataURI) : baseURI;
+};
 
 const getUrlOrRedirect = url =>
-  dataURI && url.includes('IScript_')
-    ? url.replace(/.*IScript_/, dataURI)
-    : url;
+  dataURI && url.includes('IScript_') ? url.replace(/.*\//, dataURI) : url;
 
 const isFramed = (() => {
   try {


### PR DESCRIPTION
Some previous changes to js-fetch allow the base url for namespaced service calls to be overridden by the highpoint.dataURI field. 

In CX, sometimes IScript services w/ a different base url than the current page are called by passing the full url to js-fetch. This PR adds logic to check if the full url is calling an IScript service, and if the dataURI is in use. If so, it replaces the base of the url with the dataURI.

This will guarentees that even if we pass the entire url of one of our IScript services, the url redirection will still work.